### PR TITLE
Webpack

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+   "presets": [ "react", "es2015" ],
+   "plugins": [
+      "transform-es2015-modules-commonjs",
+      "transform-react-constant-elements",
+   ]
+}

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ let App = connect(
 
 React.render(
   <Provider store={store}>
-    {() => <App />}
+    <App />
   </Provider>,
   document.getElementById('root')
 );

--- a/package.json
+++ b/package.json
@@ -26,10 +26,14 @@
     "redux": "^1.0.0-rc"
   },
   "devDependencies": {
-    "babel-core": "^5.6.18",
-    "babel-loader": "^5.1.4",
-    "react-hot-loader": "^1.2.7",
-    "webpack": "^1.9.11",
-    "webpack-dev-server": "^1.9.0"
+    "babel-core": "^6.0.16",
+    "babel-loader": "^6.0.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.0.15",
+    "babel-plugin-transform-react-constant-elements": "^6.0.14",
+    "babel-preset-es2015": "^6.0.15",
+    "babel-preset-react": "^6.0.15",
+    "react-hot-loader": "^1.3.0",
+    "webpack": "^1.12.2",
+    "webpack-dev-server": "^1.12.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   },
   "homepage": "https://github.com/jackielii/simplest-redux-example#readme",
   "dependencies": {
-    "react": "^0.13.3",
-    "react-redux": "^0.5.0",
-    "redux": "^1.0.0-rc"
+    "react": "^0.14.1",
+    "react-redux": "^4.0.0",
+    "redux": "^3.0.4"
   },
   "devDependencies": {
     "babel-core": "^6.0.16",


### PR DESCRIPTION
Update to babel v6 because it breaks react. Babel 6 handles react via special components now. Super confusing.

You maybe want to create another branch **webpack-babel6** or just merge into this.  
